### PR TITLE
Add back button to toolbar and reorder menu items

### DIFF
--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -42,6 +42,7 @@ import org.librarysimplified.r2.api.SR2Theme
 import org.librarysimplified.r2.ui_thread.SR2UIThread
 import org.librarysimplified.r2.views.SR2ReaderViewEvent.SR2ReaderViewBookEvent.SR2BookLoadingFailed
 import org.librarysimplified.r2.views.SR2ReaderViewEvent.SR2ReaderViewControllerEvent.SR2ControllerBecameAvailable
+import org.librarysimplified.r2.views.SR2ReaderViewEvent.SR2ReaderViewNavigationEvent.SR2ReaderViewNavigationClose
 import org.librarysimplified.r2.views.SR2ReaderViewEvent.SR2ReaderViewNavigationEvent.SR2ReaderViewNavigationOpenTOC
 import org.librarysimplified.r2.views.internal.SR2BrightnessService
 import org.librarysimplified.r2.views.internal.SR2SettingsDialog
@@ -119,6 +120,8 @@ class SR2ReaderFragment private constructor(
     this.toolbar.menu.findItem(R.id.readerMenuAddBookmark)
       .setOnMenuItemClickListener { this.onReaderMenuAddBookmarkSelected() }
 
+    this.toolbar.setNavigationOnClickListener { this.onToolbarNavigationSelected() }
+
     /*
      * We don't show page numbers in continuous scroll mode.
      */
@@ -160,6 +163,13 @@ class SR2ReaderFragment private constructor(
     SR2UIThread.checkIsUIThread()
 
     this.openSettings()
+    return true
+  }
+
+  private fun onToolbarNavigationSelected(): Boolean {
+    SR2UIThread.checkIsUIThread()
+
+    this.readerModel.publishViewEvent(SR2ReaderViewNavigationClose)
     return true
   }
 

--- a/org.librarysimplified.r2.views/src/main/res/drawable/sr2_arrow_back.xml
+++ b/org.librarysimplified.r2.views/src/main/res/drawable/sr2_arrow_back.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF"
+    android:autoMirrored="true">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/org.librarysimplified.r2.views/src/main/res/layout/sr2_reader.xml
+++ b/org.librarysimplified.r2.views/src/main/res/layout/sr2_reader.xml
@@ -13,11 +13,12 @@
     android:layout_height="?attr/actionBarSize"
     android:background="?attr/colorPrimary"
     android:minHeight="?attr/actionBarSize"
-    app:titleTextColor="@android:color/white"
-    tools:title="Placeholder"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toTopOf="parent"
+    app:navigationIcon="@drawable/sr2_arrow_back"
+    app:titleTextColor="@android:color/white"
+    tools:title="Placeholder" />
 
   <WebView
     android:id="@+id/readerWebView"

--- a/org.librarysimplified.r2.views/src/main/res/menu/sr2_reader_menu.xml
+++ b/org.librarysimplified.r2.views/src/main/res/menu/sr2_reader_menu.xml
@@ -3,6 +3,12 @@
 <menu xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:android="http://schemas.android.com/apk/res/android">
   <item
+    android:id="@+id/readerMenuTOC"
+    android:contentDescription="@string/readerAccessTOC"
+    android:icon="@drawable/sr2_toc"
+    android:title="@string/readerTableOfContents"
+    app:showAsAction="ifRoom" />
+  <item
     android:id="@+id/readerMenuSettings"
     android:icon="@drawable/sr2_settings"
     android:contentDescription="@string/readerAccessSettings"
@@ -13,11 +19,5 @@
     android:icon="@drawable/sr2_bookmark_inactive"
     android:contentDescription="@string/readerAccessAddBookmark"
     android:title="@string/readerAddBookmark"
-    app:showAsAction="ifRoom" />
-  <item
-    android:id="@+id/readerMenuTOC"
-    android:icon="@drawable/sr2_toc"
-    android:contentDescription="@string/readerAccessTOC"
-    android:title="@string/readerTableOfContents"
     app:showAsAction="ifRoom" />
 </menu>


### PR DESCRIPTION
**What's this do?**

This makes two adjustments to the reader toolbar:
- A back button (aka navigation icon) is added on the left
- The menu items are reordered to be TOC, Settings, Bookmarks (instead of Settings, Bookmarks, TOC)

![Screenshot_20210930_230537](https://user-images.githubusercontent.com/1395885/135559314-0015264d-a325-4182-a08a-f2a01106699f.png)

**Why are we doing this? (w/ JIRA link if applicable)**

This makes reader toolbar on Android more similar to iOS. On iOS, the toolbar has a back button, and the menu items have the TOC, Settings, Bookmarks ordering. Adding the back button also makes it easier to exit the book on Android devices that don't have the OS-provided back button enabled.

Notion tickets addressed:
- https://www.notion.so/lyrasis/Change-reader-toolbar-icon-order-e1480fc12f904b95bcf5bd3820ea3ceb
- https://www.notion.so/lyrasis/Add-back-button-to-reader-toolbar-0f25bf9b71fc4eae99b042a521d34c7e

**How should this be tested? / Do these changes have associated tests?**

Read any epub book. If the toolbar is not visible, tap in the middle of the page to open it. On the right side of the toolbar, the menu items should appear in the order (from left to right) TOC, Settings, Bookmarks. On the left side, there should be a back arrow. Tapping on the back arrow should exit the book, and return to the screen from which the book was opened (the bookshelf or book detail screen).

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran Palace with these changes.