### PR TITLE
Added fixed title to reader screen

### DIFF
--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -73,6 +73,7 @@ class SR2ReaderFragment private constructor(
   private lateinit var progressContainer: ViewGroup
   private lateinit var progressView: ProgressBar
   private lateinit var readerModel: SR2ReaderViewModel
+  private lateinit var titleText: TextView
   private lateinit var toolbar: Toolbar
   private lateinit var webView: WebView
   private var controller: SR2ControllerType? = null
@@ -110,6 +111,8 @@ class SR2ReaderFragment private constructor(
       view.findViewById(R.id.reader2_position_percent)
     this.loadingView =
       view.findViewById(R.id.readerLoading)
+    this.titleText =
+      view.findViewById(R.id.titleText)
 
     this.toolbar.inflateMenu(R.menu.sr2_reader_menu)
     this.menuBookmarkItem = this.toolbar.menu.findItem(R.id.readerMenuAddBookmark)
@@ -316,6 +319,7 @@ class SR2ReaderFragment private constructor(
         this.controller = newController
         newController.viewConnect(this.webView)
         this.toolbar.title = newController.bookMetadata.title
+        this.titleText.text = newController.bookMetadata.title
         this.readerModel.publishViewEvent(SR2ControllerBecameAvailable(event.reference))
       }
 
@@ -376,12 +380,10 @@ class SR2ReaderFragment private constructor(
   private fun showOrHideReadingUI(uiVisible: Boolean) {
     SR2UIThread.checkIsUIThread()
 
-    if (uiVisible) {
-      this.progressContainer.visibility = View.VISIBLE
-      this.toolbar.visibility = View.VISIBLE
+    this.toolbar.visibility = if (uiVisible) {
+      View.VISIBLE
     } else {
-      this.progressContainer.visibility = View.GONE
-      this.toolbar.visibility = View.GONE
+      View.GONE
     }
   }
 

--- a/org.librarysimplified.r2.views/src/main/res/layout/sr2_reader.xml
+++ b/org.librarysimplified.r2.views/src/main/res/layout/sr2_reader.xml
@@ -7,6 +7,15 @@
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
+  <TextView
+    android:id="@+id/titleText"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:gravity="center"
+    android:textAppearance="?android:textAppearanceMedium"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="Placeholder" />
+
   <androidx.appcompat.widget.Toolbar
     android:id="@+id/readerToolbar"
     android:layout_width="0dp"
@@ -26,10 +35,10 @@
     android:layout_height="0dp"
     android:layout_marginTop="8dp"
     android:layout_marginBottom="8dp"
-    app:layout_constraintBottom_toTopOf="@+id/readerProgressContainer"
+    app:layout_constraintBottom_toTopOf="@id/readerProgressContainer"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/readerToolbar" />
+    app:layout_constraintTop_toBottomOf="@id/titleText" />
 
   <include
     android:id="@+id/readerProgressContainer"


### PR DESCRIPTION
**What's this do?**
This PR changes the reader screen tap logic. Instead of showing/hiding the page progress of the book and the toolbar, which caused the contents to bounce, now the toolbar is hidden but in its place remains the title of the book, keeping the page contents fixed. Also, the page progress is now visible all the time.

**Why are we doing this? (w/ JIRA link if applicable)**
There was a bug report stating the contents were bouncing everytime the user clicked on the screen. The bug link is [here](https://www.notion.so/lyrasis/e72462c871a54c5d9b8b4cbf740cfe2f?v=32b300218b974ecdb2054533a8b4a6d2&p=317807310e2348fda272dc40f12a3a8f) and the issue video [here](https://user-images.githubusercontent.com/79104027/136107104-c0601cb1-1db6-498b-b3ca-502e4f1a6a9d.mp4)

**How should this be tested? / Do these changes have associated tests?**
Open an epub book (the toolbar is visible just like the page progress at the bottom)
Click on the center of the screen
Check the toolbar hiding and revealing the book title at the top center of the screen and check the page progress is still there.

**Dependencies for merging? Releasing to production?**
n/a

**Has the application documentation been updated for these changes?**
n/a

**Did someone actually run this code to verify it works?**
Tested by @nunommts 