### PR TITLE
Remove global variables from gestures.js.

### DIFF
--- a/org.librarysimplified.r2.vanilla/src/main/assets/readium/scripts/gestures.js
+++ b/org.librarysimplified.r2.vanilla/src/main/assets/readium/scripts/gestures.js
@@ -1,116 +1,118 @@
 "use strict";
 
-var singleTouchGesture = false;
-var startX = 0;
-var startY = 0;
-var startTime = Date.now();
-var availWidth = window.screen.availWidth;
-var availHeight = window.screen.availHeight;
+(function() {
+    var singleTouchGesture = false;
+    var startX = 0;
+    var startY = 0;
+    var startTime = Date.now();
+    var availWidth = window.screen.availWidth;
+    var availHeight = window.screen.availHeight;
 
-window.addEventListener("load", function() {
-    window.document.addEventListener("touchstart", handleTouchStart, false);
-    window.document.addEventListener("touchend", handleTouchEnd, false);
-}, false);
+    /*
+     * When a touch is detected, record the starting coordinates and properties of the event.
+     */
 
-/*
- * When a touch is detected, record the starting coordinates and properties of the event.
- */
+    var handleTouchStart = function(event) {
+        startTime = Date.now();
+        console.log("touchStart: " + startTime);
 
-var handleTouchStart = function(event) {
-    startTime = Date.now();
-    console.log("touchStart: " + startTime);
+        if (event.target.nodeName.toUpperCase() === 'A') {
+            console.log("Touched a link.");
+            singleTouchGesture = false;
+            return;
+        }
 
-    if (event.target.nodeName.toUpperCase() === 'A') {
-        console.log("Touched a link.");
-        singleTouchGesture = false;
-        return;
+        singleTouchGesture = event.touches.length == 1;
+        var touch = event.changedTouches[0];
+        startX = touch.screenX % availWidth;
+        startY = touch.screenY % availHeight;
+    };
+
+    /*
+     * Handle taps that occur within the page movement areas (the left and right edges of the screen).
+     */
+
+    var handlePageMovementTap = function(event, touch) {
+        var position = (touch.screenX % availWidth) / availWidth;
+        console.log("pageMovementTap: " + position);
+
+        if (position <= 0.2) {
+            console.log("LeftTapped");
+            Android.onLeftTapped();
+        } else if (position >= 0.8) {
+            console.log("RightTapped");
+            Android.onRightTapped();
+        } else {
+            console.log("CenterTapped");
+            Android.onCenterTapped();
+        }
+
+        event.stopPropagation();
+        event.preventDefault();
+    };
+
+    /*
+     * Handle swipes.
+     */
+
+    var handleSwipe = function(event) {
+        console.log("swipe");
+
+        var touch =
+          event.changedTouches[0];
+        var direction =
+          ((touch.screenX % availWidth) - startX) / availWidth;
+
+        if (direction > 0) {
+            console.log("swipeRight");
+            Android.onRightSwiped();
+        } else {
+            console.log("swipeLeft");
+            Android.onLeftSwiped();
+        }
+
+        event.stopPropagation();
+        event.preventDefault();
     }
 
-    singleTouchGesture = event.touches.length == 1;
-    var touch = event.changedTouches[0];
-    startX = touch.screenX % availWidth;
-    startY = touch.screenY % availHeight;
-};
+    /*
+     * When a touch ends, check if any action has to be made, and contact native code.
+     */
 
-/*
- * Handle taps that occur within the page movement areas (the left and right edges of the screen).
- */
+    var handleTouchEnd = function(event) {
+        var endTime = Date.now();
+        var timeDelta = endTime - startTime;
+        console.log("touchEnd: timeDelta: " + timeDelta);
 
-var handlePageMovementTap = function(event, touch) {
-    var position = (touch.screenX % availWidth) / availWidth;
-    console.log("pageMovementTap: " + position);
+        if (!singleTouchGesture) {
+            return;
+        }
 
-    if (position <= 0.2) {
-        console.log("LeftTapped");
-        Android.onLeftTapped();
-    } else if (position >= 0.8) {
-        console.log("RightTapped");
-        Android.onRightTapped();
-    } else {
-        console.log("CenterTapped");
-        Android.onCenterTapped();
-    }
+        var touch = event.changedTouches[0];
 
-    event.stopPropagation();
-    event.preventDefault();
-};
+        var relativeDistanceX =
+          Math.abs(((touch.screenX % availWidth) - startX) / availWidth);
+        var relativeDistanceY =
+          Math.abs(((touch.screenY % availHeight) - startY) / availHeight);
+        var touchDistance =
+          Math.max(relativeDistanceX, relativeDistanceY);
 
-/*
- * Handle swipes.
- */
+        var swipeFarEnough = relativeDistanceX > 0.25
+        var swipeFastEnough = timeDelta < 250
+        if (swipeFastEnough && swipeFarEnough) {
+            handleSwipe(event);
+            return;
+        }
 
-var handleSwipe = function(event) {
-    console.log("swipe");
+        var tapAreaSize = 0.01
+        if (touchDistance < tapAreaSize) {
+            handlePageMovementTap(event, touch);
+            return;
+        }
+    };
 
-    var touch =
-      event.changedTouches[0];
-    var direction =
-      ((touch.screenX % availWidth) - startX) / availWidth;
-
-    if (direction > 0) {
-        console.log("swipeRight");
-        Android.onRightSwiped();
-    } else {
-        console.log("swipeLeft");
-        Android.onLeftSwiped();
-    }
-
-    event.stopPropagation();
-    event.preventDefault();
-}
-
-/*
- * When a touch ends, check if any action has to be made, and contact native code.
- */
-
-var handleTouchEnd = function(event) {
-    var endTime = Date.now();
-    var timeDelta = endTime - startTime;
-    console.log("touchEnd: timeDelta: " + timeDelta);
-
-    if (!singleTouchGesture) {
-        return;
-    }
-
-    var touch = event.changedTouches[0];
-
-    var relativeDistanceX =
-      Math.abs(((touch.screenX % availWidth) - startX) / availWidth);
-    var relativeDistanceY =
-      Math.abs(((touch.screenY % availHeight) - startY) / availHeight);
-    var touchDistance =
-      Math.max(relativeDistanceX, relativeDistanceY);
-
-    var swipeFarEnough = relativeDistanceX > 0.25
-    var swipeFastEnough = timeDelta < 250
-    if (swipeFastEnough && swipeFarEnough) {
-        handleSwipe(event);
-        return;
-    }
-
-    var tapAreaSize = 0.01
-    if (touchDistance < tapAreaSize) {
-        handlePageMovementTap(event, touch);
-        return;
-    }
-};
+    window.addEventListener("load", function() {
+        window.document.addEventListener("touchstart", handleTouchStart, false);
+        window.document.addEventListener("touchend", handleTouchEnd, false);
+    }, false);
+})();


### PR DESCRIPTION
**What's this do?**

Removes global variables from the JavaScript code that we inject into books to handle gesture detection.

Note: It's much easier to view this diff when you hide whitespace changes.

This just wraps the file in an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE). We might want to modernize this JavaScript at some point, but this is the easy way that will work on old versions of the WebView.

**Why are we doing this? (w/ JIRA link if applicable)**

The epub that is being read may itself contain JavaScript, which may also set global variables. This avoids naming collisions that could occur if the JavaScript in the book wants to use the same global variable names.

Of course, there are many other problems that can happen if the book has its own JavaScript, but this at least avoids one class of them.

Notion: https://www.notion.so/lyrasis/Error-loading-Bibliotheca-book-236fd5e95e8c4a6aa07f35144328c957

**How should this be tested? / Do these changes have associated tests?**

1. Read the book "David and the Lost Lamb" from Lyrasis Reads.
2. Perform gestures on the blank part of the page (not on the image). A tap on the right side should turn to the next page. A tap on the left side should turn to the previous page. A tap in the center should toggle the toolbar. A swipe left should turn to the next page. A swipe right should turn to the previous page.
3. Read some other books, and verify that the gestures also work on those books.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee tested in the Palace app.