### PR TITLE
Fixed wrong toolbar colors when setting some styles in ebooks

### DIFF
--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.r2.views
 
 import android.content.Intent
+import android.graphics.PorterDuff
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -14,6 +15,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.MenuItemCompat
+import androidx.core.view.forEach
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.google.common.base.Preconditions
@@ -186,6 +188,12 @@ class SR2ReaderFragment private constructor(
     val background = theme.colorScheme.background()
     val foreground = theme.colorScheme.foreground()
 
+    this.toolbar.setBackgroundColor(background)
+    this.toolbar.setTitleTextColor(foreground)
+    this.toolbar.navigationIcon?.setColorFilter(foreground, PorterDuff.Mode.SRC_ATOP)
+    this.toolbar.menu.forEach { item ->
+      item.icon.setColorFilter(foreground, PorterDuff.Mode.SRC_ATOP)
+    }
     this.container.setBackgroundColor(background)
     this.positionPageView.setTextColor(foreground)
     this.positionTitleView.setTextColor(foreground)
@@ -285,6 +293,7 @@ class SR2ReaderFragment private constructor(
 
     val controllerNow = this.controller
     if (controllerNow != null) {
+      val currentColorFilter = menuBookmarkItem.icon.colorFilter
       val bookmark = this.findBookmarkForCurrentPage(controllerNow, currentPosition)
       if (bookmark != null) {
         this.menuBookmarkItem.setIcon(R.drawable.sr2_bookmark_active)
@@ -299,6 +308,7 @@ class SR2ReaderFragment private constructor(
           this.resources.getString(R.string.readerAccessAddBookmark)
         )
       }
+      menuBookmarkItem.icon.colorFilter = currentColorFilter
     }
   }
 

--- a/org.librarysimplified.r2.views/src/main/res/layout/sr2_reader.xml
+++ b/org.librarysimplified.r2.views/src/main/res/layout/sr2_reader.xml
@@ -26,7 +26,6 @@
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent"
     app:navigationIcon="@drawable/sr2_arrow_back"
-    app:titleTextColor="?attr/simplifiedColorText"
     tools:title="Placeholder" />
 
   <WebView


### PR DESCRIPTION
**What's this do?**
This PR changes the toolbar background and text colors and the toolbar icon colors when the user changes the style in the ebook reader settings.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [bug report](https://www.notion.so/lyrasis/The-navigation-bar-epub-should-be-black-when-the-WHITE_TEXT_ON_BLACK-setting-is-enabled-7b0a78717c674ca2898a08b26a6abc47) saying the Android app isn't updating the toolbar colors after changing the ebook style which makes the toolbar options unreadable. This PR fixes it to make the UX more pleasant to use.

**How should this be tested? / Do these changes have associated tests?**
Open the app
Choose any ebook
Click on the "Settings" option in the toolbar
Change to the dark theme and see it's similar [to this](https://user-images.githubusercontent.com/79104027/152787985-39ee82c6-62c8-468f-9645-3021d393e84f.png)
Change to the sepia theme and see it's similar [to this](https://user-images.githubusercontent.com/79104027/152788037-aaa7f215-3052-43f3-be75-c639bc29e990.png)

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 