### PR TITLE
Added content description to back button on reader screen

### DIFF
--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -127,6 +127,7 @@ class SR2ReaderFragment private constructor(
       .setOnMenuItemClickListener { this.onReaderMenuAddBookmarkSelected() }
 
     this.toolbar.setNavigationOnClickListener { this.onToolbarNavigationSelected() }
+    this.toolbar.setNavigationContentDescription(R.string.settingsAccessibilityBack)
 
     /*
      * We don't show page numbers in continuous scroll mode.

--- a/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
+++ b/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
@@ -30,6 +30,7 @@
   <string name="tocAccessChapter">Open Chapter %1$d: %2$s</string>
   <string name="publisherDefaults">Publisher Defaults</string>
 
+  <string name="settingsAccessibilityBack">Back</string>
   <string name="settingsAccessibilitySetPublisher">Show the publisher-specified fonts and layout choices.</string>
   <string name="settingsAccessibilitySetSans">Set book font to sans-serif.</string>
   <string name="settingsAccessibilitySetSerif">Set book font to serif.</string>


### PR DESCRIPTION
**What's this do?**
This PR adds a content description to the back button on the toolbar of the reader screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [ticket with a bug](https://www.notion.so/lyrasis/Android-There-are-unlabeled-buttons-on-the-book-reading-and-listening-screens-1847df33398945e487c8f0e6b3a136df) saying that the back button of the reader's toolbar doesn't display a "Text" value when selecting on the inspect mode of the BrowserStack.

**How should this be tested? / Do these changes have associated tests?**
The [BrowserStack now displays the "Back" label](https://user-images.githubusercontent.com/79104027/192505454-7dd41e87-dcdb-4fd3-9846-449329c60a01.png) on the Inspect Mode, but this can be tested by:

1. Turn the TalkBack feature of the phone in the Accessibility options
2. Open the Palace app
3. Select "LYRASIS Reads"
4. Search for "The Prince and the pauper" and open it
5. Start reading it
6. Click on the "Back" button.

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 