### PR TITLE
Target Android 12 (API 32).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -9,9 +9,10 @@
         <c:change date="2022-05-03T00:00:00+00:00" summary="Update R2 libraries version"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-05T04:09:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2022-10-20T06:08:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
-        <c:change date="2022-10-05T04:09:38+00:00" summary="Added content description to back button on reader screen"/>
+        <c:change date="2022-10-05T00:00:00+00:00" summary="Added content description to back button on reader screen"/>
+        <c:change date="2022-10-20T06:08:38+00:00" summary="Changed target version to Android 12."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
-  if ("$gradle.gradleVersion" != "7.2") {
-    throw new GradleException("Gradle version 7.2 is required (received $gradle.gradleVersion)")
+  if ("$gradle.gradleVersion" != "7.4") {
+    throw new GradleException("Gradle version 7.4 is required (received $gradle.gradleVersion)")
   }
 
   ext.kotlin_version = "1.5.30"
@@ -15,7 +15,7 @@ buildscript {
     classpath "biz.aQute.bnd:biz.aQute.bnd.gradle:5.3.0"
     classpath "digital.wup:android-maven-publish:3.6.3"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath 'com.android.tools.build:gradle:7.0.2'
+    classpath 'com.android.tools.build:gradle:7.3.1'
   }
 }
 
@@ -26,9 +26,9 @@ plugins {
 }
 
 ext {
-  androidCompileSDKVersion = 31
+  androidCompileSDKVersion = 32
   androidMinimumSDKVersion = 21
-  androidTargetSDKVersion = 31
+  androidTargetSDKVersion = 32
 
   if (!project.hasProperty("mavenCentralUsername")) {
     logger.warn("No mavenCentralUsername property specified: Using an empty value")
@@ -64,6 +64,19 @@ allprojects {
 }
 
 subprojects { project ->
+  // Workaround for failing readium nanohttpd artifact downloads. Remove this when readium has
+  // fixed the issue.
+  project.configurations.all {
+    resolutionStrategy {
+      dependencySubstitution {
+        all { DependencySubstitution dependency ->
+          if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == 'com.github.edrlab.nanohttpd') {
+            dependency.useTarget ('com.github.readium.nanohttpd:' + dependency.requested.module + ':' + dependency.requested.version, 'because nanohttpd ownership changed from edrlab to readium')
+          }
+        }
+      }
+    }
+  }
 
   switch (POM_PACKAGING) {
     case "jar":

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**What's this do?**

This updates the app to target Android 12 (API 32), including necessary dependency and gradle upgrades.

It also includes a workaround for the currently failing readium nanohttpd artifact downloads, which can be removed when that problem is fixed by readium.

**Why are we doing this? (w/ JIRA link if applicable)**

Apps will be required to target Android 12 in November. Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

**How should this be tested? / Do these changes have associated tests?**

EPUB books should open successfully, and the controls and table of contents should all work.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee read some epubs.