### PR TITLE
Added back button to TOC screen

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -9,10 +9,11 @@
         <c:change date="2022-05-03T00:00:00+00:00" summary="Update R2 libraries version"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-20T06:08:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2022-10-27T10:09:17+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2022-10-05T00:00:00+00:00" summary="Added content description to back button on reader screen"/>
-        <c:change date="2022-10-20T06:08:38+00:00" summary="Changed target version to Android 12."/>
+        <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
+        <c:change date="2022-10-27T10:09:17+00:00" summary="Added back button to TOC screen."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2TOCFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2TOCFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayout
@@ -26,6 +27,7 @@ class SR2TOCFragment private constructor(
   private lateinit var viewPagerAdapter: SR2TOCAdapter
   private lateinit var viewPager: ViewPager2
   private lateinit var tabLayout: TabLayout
+  private lateinit var toolbar: Toolbar
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -39,6 +41,8 @@ class SR2TOCFragment private constructor(
       view.findViewById(R.id.tocTabs)
     this.viewPager =
       view.findViewById(R.id.tocViewPager)
+    this.toolbar =
+      view.findViewById(R.id.tocToolbar)
     this.viewPagerAdapter =
       SR2TOCAdapter(
         fragment = this,
@@ -55,6 +59,9 @@ class SR2TOCFragment private constructor(
       )
 
     this.viewPager.adapter = this.viewPagerAdapter
+
+    this.toolbar.setNavigationOnClickListener { activity?.onBackPressed() }
+    this.toolbar.setNavigationContentDescription(R.string.settingsAccessibilityBack)
 
     TabLayoutMediator(this.tabLayout, this.viewPager) { tab, position ->
       tab.text = this.viewPagerAdapter.titleOf(position)

--- a/org.librarysimplified.r2.views/src/main/res/layout/sr2_table_of_contents.xml
+++ b/org.librarysimplified.r2.views/src/main/res/layout/sr2_table_of_contents.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.constraintlayout.widget.ConstraintLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:id="@+id/tocLayout"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
   android:orientation="vertical">
+
+  <androidx.appcompat.widget.Toolbar
+    android:id="@+id/tocToolbar"
+    android:layout_width="0dp"
+    android:layout_height="?attr/actionBarSize"
+    android:minHeight="?attr/actionBarSize"
+    android:theme="?android:attr/actionBarTheme"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    app:navigationIcon="@drawable/sr2_arrow_back" />
 
   <com.google.android.material.tabs.TabLayout
     android:id="@+id/tocTabs"
@@ -14,9 +24,9 @@
     android:layout_height="64dp"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:tabMaxWidth="0dp"
+    app:layout_constraintTop_toBottomOf="@id/tocToolbar"
     app:tabGravity="fill"
+    app:tabMaxWidth="0dp"
     app:tabMode="fixed">
 
     <com.google.android.material.tabs.TabItem
@@ -30,16 +40,16 @@
       android:layout_width="match_parent"
       android:layout_height="match_parent"
       android:text="@string/tocBookmarks" />
+
   </com.google.android.material.tabs.TabLayout>
 
   <androidx.viewpager2.widget.ViewPager2
     android:id="@+id/tocViewPager"
     android:layout_width="0dp"
     android:layout_height="0dp"
-    android:layout_marginTop="64dp"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toBottomOf="@id/tocTabs" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**What's this do?**
This PR adds a back button to the TOC screen.

**Why are we doing this? (w/ JIRA link if applicable)**
There's a [feature request](https://www.notion.so/lyrasis/Android-Add-a-Back-button-to-Table-of-Contents-Bookmarks-area-in-app-0d911e2d72144cd582b709fd41edd077) saying the UX could be improved by adding a back button to the TOC screen to help the user to return to the previous screen without inadvertently tap a location or bookmark on the screen.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select LYRASIS Reads  library
Borrow a title or open a book
Click on the TOC icon
Confirm [the back button is there](https://user-images.githubusercontent.com/79104027/198272791-278b2290-5eec-4108-8880-46b5f094305d.png)  and click on it
Confirm you're back to the previous page

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**