### PR TITLE
Target Android 13 (API 33).

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -9,11 +9,12 @@
         <c:change date="2022-05-03T00:00:00+00:00" summary="Update R2 libraries version"/>
       </c:changes>
     </c:release>
-    <c:release date="2022-10-27T10:09:17+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
+    <c:release date="2022-10-27T17:21:38+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.3">
       <c:changes>
         <c:change date="2022-10-05T00:00:00+00:00" summary="Added content description to back button on reader screen"/>
         <c:change date="2022-10-20T00:00:00+00:00" summary="Changed target version to Android 12."/>
-        <c:change date="2022-10-27T10:09:17+00:00" summary="Added back button to TOC screen."/>
+        <c:change date="2022-10-27T00:00:00+00:00" summary="Added back button to TOC screen."/>
+        <c:change date="2022-10-27T17:21:38+00:00" summary="Changed target version to Android 13."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,9 @@ plugins {
 }
 
 ext {
-  androidCompileSDKVersion = 32
+  androidCompileSDKVersion = 33
   androidMinimumSDKVersion = 21
-  androidTargetSDKVersion = 32
+  androidTargetSDKVersion = 33
 
   if (!project.hasProperty("mavenCentralUsername")) {
     logger.warn("No mavenCentralUsername property specified: Using an empty value")
@@ -64,20 +64,6 @@ allprojects {
 }
 
 subprojects { project ->
-  // Workaround for failing readium nanohttpd artifact downloads. Remove this when readium has
-  // fixed the issue.
-  project.configurations.all {
-    resolutionStrategy {
-      dependencySubstitution {
-        all { DependencySubstitution dependency ->
-          if (dependency.requested instanceof ModuleComponentSelector && dependency.requested.group == 'com.github.edrlab.nanohttpd') {
-            dependency.useTarget ('com.github.readium.nanohttpd:' + dependency.requested.module + ':' + dependency.requested.version, 'because nanohttpd ownership changed from edrlab to readium')
-          }
-        }
-      }
-    }
-  }
-
   switch (POM_PACKAGING) {
     case "jar":
       logger.info("Configuring ${project} (${POM_PACKAGING}) as jar project")

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -193,7 +193,7 @@ class SR2ReaderFragment private constructor(
     this.toolbar.setTitleTextColor(foreground)
     this.toolbar.navigationIcon?.setColorFilter(foreground, PorterDuff.Mode.SRC_ATOP)
     this.toolbar.menu.forEach { item ->
-      item.icon.setColorFilter(foreground, PorterDuff.Mode.SRC_ATOP)
+      item.icon?.setColorFilter(foreground, PorterDuff.Mode.SRC_ATOP)
     }
     this.container.setBackgroundColor(background)
     this.positionPageView.setTextColor(foreground)
@@ -294,7 +294,7 @@ class SR2ReaderFragment private constructor(
 
     val controllerNow = this.controller
     if (controllerNow != null) {
-      val currentColorFilter = menuBookmarkItem.icon.colorFilter
+      val currentColorFilter = menuBookmarkItem.icon?.colorFilter
       val bookmark = this.findBookmarkForCurrentPage(controllerNow, currentPosition)
       if (bookmark != null) {
         this.menuBookmarkItem.setIcon(R.drawable.sr2_bookmark_active)
@@ -309,7 +309,7 @@ class SR2ReaderFragment private constructor(
           this.resources.getString(R.string.readerAccessAddBookmark)
         )
       }
-      menuBookmarkItem.icon.colorFilter = currentColorFilter
+      menuBookmarkItem.icon?.colorFilter = currentColorFilter
     }
   }
 


### PR DESCRIPTION
**What's this do?**

This updates the app to target Android 13 (API 33).

Some additional null checks that are now needed have been added.

It also removes the workaround for failing readium nanohttpd artifact downloads, since that problem has been fixed by readium.

**Why are we doing this? (w/ JIRA link if applicable)**

Notion: https://www.notion.so/lyrasis/Update-Android-app-to-target-Android-13-2d0216494ad846579321de4b5a4c932f

**How should this be tested? / Do these changes have associated tests?**

EPUB books should open successfully, and the controls and table of contents should all work.

**Dependencies for merging? Releasing to production?**

None.

**Have you updated the changelog?**

Yes.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee read some epubs.