### PR TITLE
Fixed book title not being displayed with dark background

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -17,8 +17,10 @@
         <c:change date="2022-10-27T00:00:00+00:00" summary="Changed target version to Android 13."/>
       </c:changes>
     </c:release>
-    <c:release date="2022-12-08T03:07:25+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
-      <c:changes/>
+    <c:release date="2023-01-10T22:51:57+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
+      <c:changes>
+        <c:change date="2023-01-10T22:51:57+00:00" summary="Fixed book title not being displayed with dark background."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -196,6 +196,7 @@ class SR2ReaderFragment private constructor(
       item.icon?.setColorFilter(foreground, PorterDuff.Mode.SRC_ATOP)
     }
     this.container.setBackgroundColor(background)
+    this.titleText.setTextColor(foreground)
     this.positionPageView.setTextColor(foreground)
     this.positionTitleView.setTextColor(foreground)
     this.positionPercentView.setTextColor(foreground)


### PR DESCRIPTION
**What's this do?**
This PR changes the color of the title that's underneath the toolbar on a ebook's reader when the color scheme is changed on settings.

**Why are we doing this? (w/ JIRA link if applicable)**
There's [a ticket](https://www.notion.so/Android-The-full-title-of-the-book-becomes-invisible-after-hiding-the-toolbar-when-a-black-color-sc-21a57df1ad134a5c9a1a18e0e865b603) reporting that a ebook's title can't be seen after changing the style's color scheme to black.

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads" library
Open an ebook
Go to the settings and switch to the black color scheme
Close the settings
Tap on the screen to hide the toolbar
Confirm the title can be read

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 