### PR TITLE
Add support to book previews

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -17,9 +17,10 @@
         <c:change date="2022-10-27T00:00:00+00:00" summary="Changed target version to Android 13."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-01-10T22:51:57+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
+    <c:release date="2023-02-13T17:36:05+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.4">
       <c:changes>
-        <c:change date="2023-01-10T22:51:57+00:00" summary="Fixed book title not being displayed with dark background."/>
+        <c:change date="2023-01-10T00:00:00+00:00" summary="Fixed book title not being displayed with dark background."/>
+        <c:change date="2023-02-13T17:36:05+00:00" summary="Added support for book previews."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoActivity.kt
+++ b/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoActivity.kt
@@ -152,6 +152,7 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
         contentProtections = emptyList(),
         bookFile = FileAsset(file),
         bookId = this.epubId!!,
+        isPreview = false,
         theme = database.theme(),
         controllers = SR2Controllers(),
         scrollingMode = if (this.scrollMode.isChecked) {

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -123,8 +123,10 @@ class SR2ReaderFragment private constructor(
       .setOnMenuItemClickListener { this.onReaderMenuSettingsSelected() }
     this.toolbar.menu.findItem(R.id.readerMenuTOC)
       .setOnMenuItemClickListener { this.onReaderMenuTOCSelected() }
-    this.toolbar.menu.findItem(R.id.readerMenuAddBookmark)
-      .setOnMenuItemClickListener { this.onReaderMenuAddBookmarkSelected() }
+
+    val addBookmarkOption = this.toolbar.menu.findItem(R.id.readerMenuAddBookmark)
+    addBookmarkOption.setOnMenuItemClickListener { this.onReaderMenuAddBookmarkSelected() }
+    addBookmarkOption.isVisible = !this.parameters.isPreview
 
     this.toolbar.setNavigationOnClickListener { this.onToolbarNavigationSelected() }
     this.toolbar.setNavigationContentDescription(R.string.settingsAccessibilityBack)

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderParameters.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderParameters.kt
@@ -33,6 +33,13 @@ data class SR2ReaderParameters(
   val bookId: String,
 
   /**
+   * A flag that indicates if the reader will be open for a book preview or not in order to know
+   * what options should be displayed to the user.
+   */
+
+  val isPreview: Boolean,
+
+  /**
    * The initial theme used for the reader.
    */
 


### PR DESCRIPTION
**What's this do?**
This PR adds a flag to indicate if the reader will be opened for a book preview or not, in order to know what options should be displayed.

**Why are we doing this? (w/ JIRA link if applicable)**
The book preview's on Palace app require a reader for the previews so we can take advantage of our current reader. However, the bookmarks option should not be displayed to the user when it comes to a book preview and then we need to hide it when a preview will be displayed

**How should this be tested? / Do these changes have associated tests?**
Follow the _Book preview_ section from the testing steps on [this PR](https://github.com/ThePalaceProject/android-core/pull/165)

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/165) needs to be merged in order to test this.

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 