### PR TITLE
Added message on bookmarks screen when there are no bookmarks

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -23,8 +23,10 @@
         <c:change date="2023-02-13T00:00:00+00:00" summary="Added support for book previews."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-03-14T21:00:23+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
-      <c:changes/>
+    <c:release date="2023-06-22T16:19:08+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
+      <c:changes>
+        <c:change date="2023-06-22T16:19:08+00:00" summary="Added message on bookmarks screen when there are no bookmarks."/>
+      </c:changes>
     </c:release>
   </c:releases>
   <c:ticket-systems>

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarksFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarksFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.annotation.UiThread
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
@@ -37,6 +38,7 @@ internal class SR2TOCBookmarksFragment private constructor(
   }
 
   private lateinit var lastReadItem: SR2TOCBookmarkViewHolder
+  private lateinit var emptyMessage: TextView
   private lateinit var bookmarkAdapter: SR2TOCBookmarkAdapter
   private lateinit var controller: SR2ControllerType
   private lateinit var readerModel: SR2ReaderViewModel
@@ -67,6 +69,8 @@ internal class SR2TOCBookmarksFragment private constructor(
 
     val recyclerView =
       layout.findViewById<RecyclerView>(R.id.tocBookmarksList)
+
+    emptyMessage = layout.findViewById(R.id.empty_bookmarks_text)
 
     recyclerView.adapter = this.bookmarkAdapter
     recyclerView.setHasFixedSize(true)
@@ -111,7 +115,8 @@ internal class SR2TOCBookmarksFragment private constructor(
 
     val bookmarksNow = this.controller.bookmarksNow()
     this.logger.debug("received {} bookmarks", bookmarksNow.size)
-    this.bookmarkAdapter.setBookmarks(bookmarksNow.filter { it.type != LAST_READ })
+    val bookmarks = bookmarksNow.filter { it.type != LAST_READ }
+    this.bookmarkAdapter.setBookmarks(bookmarks)
 
     val lastRead = bookmarksNow.find { it.type == LAST_READ }
     if (lastRead != null) {
@@ -124,6 +129,12 @@ internal class SR2TOCBookmarksFragment private constructor(
       )
     } else {
       this.lastReadItem.rootView.visibility = View.GONE
+    }
+
+    emptyMessage.visibility = if (bookmarks.isEmpty() && lastRead == null) {
+      View.VISIBLE
+    } else {
+      View.GONE
     }
   }
 

--- a/org.librarysimplified.r2.views/src/main/res/layout/sr2_toc_bookmarks.xml
+++ b/org.librarysimplified.r2.views/src/main/res/layout/sr2_toc_bookmarks.xml
@@ -2,6 +2,7 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="match_parent">
 
@@ -13,6 +14,20 @@
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
+
+  <TextView
+    android:id="@+id/empty_bookmarks_text"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:layout_margin="24dp"
+    android:gravity="center"
+    android:text="@string/emptyBookmarksMessage"
+    android:textSize="16sp"
+    android:visibility="gone"
+    app:layout_constraintBottom_toBottomOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:visibility="visible" />
 
   <View
     android:id="@+id/tocBookmarksDivider"

--- a/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
+++ b/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
@@ -29,6 +29,7 @@
   <string name="tocError">No entries available.</string>
   <string name="tocAccessChapter">Open Chapter %1$d: %2$s</string>
   <string name="publisherDefaults">Publisher Defaults</string>
+  <string name="emptyBookmarksMessage">There are no bookmarks for this book</string>
 
   <string name="settingsAccessibilityBack">Back</string>
   <string name="settingsAccessibilitySetPublisher">Show the publisher-specified fonts and layout choices.</string>


### PR DESCRIPTION
**What's this do?**
This PR adds a "no bookmarks" message to the bookmarks screen when there are no bookmarks.

**Why are we doing this? (w/ JIRA link if applicable)**
A [bug was reported](https://ebce-lyrasis.atlassian.net/browse/PP-50) saying the message was missing on the ePubs reader

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select "LYRASIS Reads" library
Open "Legends of the North Cascades" by Jonathan Evison
Open the TOC and go to "Bookmarks"
Confirm the empty bookmarks message is displayed
Return and add scroll a few pages
Go back to the "Bookmarks" page
Confirm the bookmark is displayed and the message is gone

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/188) needs to be merged too so this can be tested on the Palace app

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 