### PR TITLE
Fixed bug of bookmarks list being wrongly updated after deleting a bookmark

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -23,9 +23,10 @@
         <c:change date="2023-02-13T00:00:00+00:00" summary="Added support for book previews."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-06-22T16:19:08+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
+    <c:release date="2023-07-03T11:45:08+00:00" is-open="true" ticket-system="org.nypl.jira" version="1.0.5">
       <c:changes>
-        <c:change date="2023-06-22T16:19:08+00:00" summary="Added message on bookmarks screen when there are no bookmarks."/>
+        <c:change date="2023-06-22T00:00:00+00:00" summary="Added message on bookmarks screen when there are no bookmarks."/>
+        <c:change date="2023-07-03T11:45:08+00:00" summary="Fixed bug of bookmark not being deleted right after being added."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/ThePalaceProject/android-r2
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/ThePalaceProject/android-r2
 POM_SCM_URL=http://github.com/ThePalaceProject/android-r2
 POM_URL=http://github.com/ThePalaceProject/android-r2
-VERSION_NAME=1.0.5-SNAPSHOT
+VERSION_NAME=2.0.0-SNAPSHOT
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Bookmark.kt
+++ b/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Bookmark.kt
@@ -1,6 +1,7 @@
 package org.librarysimplified.r2.api
 
 import org.joda.time.DateTime
+import java.net.URI
 
 /**
  * A bookmark.
@@ -36,13 +37,51 @@ data class SR2Bookmark(
    * An estimate of the current progress through the entire book.
    */
 
-  val bookProgress: Double?
+  val bookProgress: Double?,
+
+  /**
+   * The URI of the bookmark, if any.
+   */
+
+  val uri: URI?,
+
+  /**
+   * A flag that indicates if the bookmark is being deleted or not.
+   */
+
+  var isBeingDeleted: Boolean = false
 ) {
 
   init {
     require(this.bookProgress == null || this.bookProgress in 0.0..1.0) {
       "Book progress must be in the range [0, 1]"
     }
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as SR2Bookmark
+
+    if (date != other.date) return false
+    if (type != other.type) return false
+    if (title != other.title) return false
+    if (locator != other.locator) return false
+    if (bookProgress != other.bookProgress) return false
+    if (uri != other.uri) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = date.hashCode()
+    result = 31 * result + type.hashCode()
+    result = 31 * result + title.hashCode()
+    result = 31 * result + locator.hashCode()
+    result = 31 * result + (bookProgress?.hashCode() ?: 0)
+    result = 31 * result + (uri?.hashCode() ?: 0)
+    return result
   }
 
   /**

--- a/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Event.kt
+++ b/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Event.kt
@@ -79,6 +79,14 @@ sealed class SR2Event {
   sealed class SR2BookmarkEvent : SR2Event() {
 
     /**
+     * Create a bookmark.
+     */
+    data class SR2BookmarkCreate(
+      val bookmark: SR2Bookmark,
+      val onBookmarkCreationCompleted: (SR2Bookmark?) -> Unit
+    ) : SR2BookmarkEvent()
+
+    /**
      * A bookmark was created.
      */
 
@@ -92,6 +100,21 @@ sealed class SR2Event {
 
     data class SR2BookmarkDeleted(
       val bookmark: SR2Bookmark
+    ) : SR2BookmarkEvent()
+
+    /**
+     * A bookmark failed to be deleted.
+     */
+
+    object SR2BookmarkFailedToBeDeleted : SR2BookmarkEvent()
+
+    /**
+     * Try to delete a bookmark.
+     */
+
+    data class SR2BookmarkTryToDelete(
+      val bookmark: SR2Bookmark,
+      val onDeleteOperationFinished: (Boolean) -> Unit
     ) : SR2BookmarkEvent()
 
     /**

--- a/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoActivity.kt
+++ b/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoActivity.kt
@@ -18,8 +18,11 @@ import io.reactivex.disposables.Disposable
 import org.librarysimplified.r2.api.SR2Command
 import org.librarysimplified.r2.api.SR2ControllerType
 import org.librarysimplified.r2.api.SR2Event
+import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkCreate
 import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkCreated
 import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkDeleted
+import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkFailedToBeDeleted
+import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkTryToDelete
 import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarksLoaded
 import org.librarysimplified.r2.api.SR2Event.SR2CommandEvent.SR2CommandEventCompleted.SR2CommandExecutionFailed
 import org.librarysimplified.r2.api.SR2Event.SR2CommandEvent.SR2CommandEventCompleted.SR2CommandExecutionSucceeded
@@ -183,7 +186,10 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
     selectFileArea.visibility = View.GONE
 
     this.supportFragmentManager.beginTransaction()
-      .replace(R.id.demoFragmentArea, this.readerFragmentFactory.instantiate(this.classLoader, SR2ReaderFragment::class.java.name))
+      .replace(
+        R.id.demoFragmentArea,
+        this.readerFragmentFactory.instantiate(this.classLoader, SR2ReaderFragment::class.java.name)
+      )
       .commit()
   }
 
@@ -216,7 +222,10 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
 
   private fun openTOC() {
     this.supportFragmentManager.beginTransaction()
-      .replace(R.id.demoFragmentArea, this.readerFragmentFactory.instantiate(this.classLoader, SR2TOCFragment::class.java.name))
+      .replace(
+        R.id.demoFragmentArea,
+        this.readerFragmentFactory.instantiate(this.classLoader, SR2TOCFragment::class.java.name)
+      )
       .addToBackStack(null)
       .commit()
   }
@@ -226,10 +235,11 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
    */
 
   private fun onControllerEvent(event: SR2Event) {
-    return when (event) {
-      is SR2BookmarkCreated -> {
+    when (event) {
+      is SR2BookmarkCreate -> {
         val database = DemoApplication.application.database()
         database.bookmarkSave(this.controller!!.bookMetadata.id, event.bookmark)
+        event.onBookmarkCreationCompleted(event.bookmark)
       }
 
       is SR2BookmarkDeleted -> {
@@ -242,9 +252,12 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
         database.themeSet(event.theme)
       }
 
+      is SR2BookmarkCreated,
       is SR2OnCenterTapped,
       is SR2ReadingPositionChanged,
       SR2BookmarksLoaded,
+      SR2BookmarkFailedToBeDeleted,
+      is SR2BookmarkTryToDelete,
       is SR2ChapterNonexistent,
       is SR2WebViewInaccessible,
       is SR2ExternalLinkSelected,

--- a/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoDatabase.kt
+++ b/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoDatabase.kt
@@ -16,6 +16,7 @@ import java.io.File
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.io.Serializable
+import java.net.URI
 import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
@@ -49,7 +50,8 @@ class DemoDatabase(private val context: Context) {
     val title: String,
     val chapterHref: String,
     val chapterProgress: Double,
-    val bookProgress: Double = 0.0
+    val bookProgress: Double = 0.0,
+    val uri: URI?
   ) : Serializable
 
   private fun countBookmarks(map: Map<String, List<SerializableBookmark>>): Int {
@@ -71,7 +73,8 @@ class DemoDatabase(private val context: Context) {
           type = bookmark.type,
           title = bookmark.title,
           locator = SR2LocatorPercent(bookmark.chapterHref, bookmark.chapterProgress),
-          bookProgress = bookmark.bookProgress
+          bookProgress = bookmark.bookProgress,
+          uri = bookmark.uri
         )
       }
   }
@@ -125,7 +128,8 @@ class DemoDatabase(private val context: Context) {
           type = bookmark.type,
           title = bookmark.title,
           chapterHref = bookmark.locator.chapterHref,
-          chapterProgress = locator.chapterProgress
+          chapterProgress = locator.chapterProgress,
+          uri = bookmark.uri
         )
       }
       is SR2LocatorChapterEnd -> {
@@ -134,7 +138,8 @@ class DemoDatabase(private val context: Context) {
           type = bookmark.type,
           title = bookmark.title,
           chapterHref = bookmark.locator.chapterHref,
-          chapterProgress = 1.0
+          chapterProgress = 1.0,
+          uri = bookmark.uri
         )
       }
     }

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
@@ -23,8 +23,11 @@ import org.librarysimplified.r2.api.SR2Command
 import org.librarysimplified.r2.api.SR2ControllerConfiguration
 import org.librarysimplified.r2.api.SR2ControllerType
 import org.librarysimplified.r2.api.SR2Event
+import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkCreate
 import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkCreated
 import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkDeleted
+import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkFailedToBeDeleted
+import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarkTryToDelete
 import org.librarysimplified.r2.api.SR2Event.SR2BookmarkEvent.SR2BookmarksLoaded
 import org.librarysimplified.r2.api.SR2Event.SR2CommandEvent.SR2CommandEventCompleted.SR2CommandExecutionFailed
 import org.librarysimplified.r2.api.SR2Event.SR2CommandEvent.SR2CommandEventCompleted.SR2CommandExecutionSucceeded
@@ -300,7 +303,8 @@ internal class SR2Controller private constructor(
           type = LAST_READ,
           title = position.chapterTitle ?: "",
           locator = position.locator,
-          bookProgress = this.currentBookProgress
+          bookProgress = this.currentBookProgress,
+          uri = null
         )
         val newBookmarks = this.bookmarks.toMutableList()
         newBookmarks.removeAll { bookmark -> bookmark.type == LAST_READ }
@@ -411,12 +415,31 @@ internal class SR2Controller private constructor(
   private fun executeCommandBookmarkDelete(
     apiCommand: SR2Command.BookmarkDelete
   ): ListenableFuture<*> {
-    val newBookmarks = this.bookmarks.toMutableList()
-    val removed = newBookmarks.remove(apiCommand.bookmark)
-    if (removed) {
-      this.bookmarks = newBookmarks.toList()
-      this.eventSubject.onNext(SR2BookmarkDeleted(apiCommand.bookmark))
+    this.bookmarks = this.bookmarks.map { bookmark ->
+      bookmark.copy(
+        isBeingDeleted = bookmark == apiCommand.bookmark
+      )
     }
+    this.eventSubject.onNext(
+      SR2BookmarkTryToDelete(
+        bookmark = apiCommand.bookmark,
+        onDeleteOperationFinished = { wasDeleted ->
+          if (wasDeleted) {
+            val newBookmarks = this.bookmarks.toMutableList()
+            newBookmarks.remove(apiCommand.bookmark)
+            this.bookmarks = newBookmarks.toList()
+            this.eventSubject.onNext(SR2BookmarkDeleted(apiCommand.bookmark))
+          } else {
+            this.bookmarks = this.bookmarks.map { bookmark ->
+              bookmark.copy(
+                isBeingDeleted = false
+              )
+            }
+            this.eventSubject.onNext(SR2BookmarkFailedToBeDeleted)
+          }
+        }
+      )
+    )
     return Futures.immediateFuture(Unit)
   }
 
@@ -430,14 +453,28 @@ internal class SR2Controller private constructor(
         date = DateTime.now(),
         type = SR2Bookmark.Type.EXPLICIT,
         title = this.currentTarget.node.title,
-        locator = SR2LocatorPercent(this.currentTarget.node.navigationPoint.locator.chapterHref, this.currentTargetProgress),
-        bookProgress = this.currentBookProgress
+        locator = SR2LocatorPercent(
+          this.currentTarget.node.navigationPoint.locator.chapterHref,
+          this.currentTargetProgress
+        ),
+        bookProgress = this.currentBookProgress,
+        uri = null
       )
 
-    val newBookmarks = this.bookmarks.toMutableList()
-    newBookmarks.add(bookmark)
-    this.bookmarks = newBookmarks.toList()
-    this.eventSubject.onNext(SR2BookmarkCreated(bookmark))
+    this.eventSubject.onNext(
+      SR2BookmarkCreate(
+        bookmark = bookmark,
+        onBookmarkCreationCompleted = { createdBookmark ->
+          if (createdBookmark != null) {
+            val newBookmarks = this.bookmarks.toMutableList()
+            newBookmarks.add(createdBookmark)
+            this.bookmarks = newBookmarks.toList()
+            this.eventSubject.onNext(SR2BookmarkCreated(createdBookmark))
+          }
+        }
+      )
+    )
+
     return Futures.immediateFuture(Unit)
   }
 

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
@@ -432,7 +432,11 @@ internal class SR2Controller private constructor(
           } else {
             this.bookmarks = this.bookmarks.map { bookmark ->
               bookmark.copy(
-                isBeingDeleted = false
+                isBeingDeleted = if (bookmark == apiCommand.bookmark) {
+                  false
+                } else {
+                  bookmark.isBeingDeleted
+                }
               )
             }
             this.eventSubject.onNext(SR2BookmarkFailedToBeDeleted)

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2DiffUtils.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2DiffUtils.kt
@@ -18,7 +18,7 @@ internal object SR2DiffUtils {
         oldItem: SR2Bookmark,
         newItem: SR2Bookmark
       ): Boolean =
-        oldItem == newItem
+        oldItem == newItem && oldItem.isBeingDeleted == newItem.isBeingDeleted
     }
 
   val tocEntryCallback: DiffUtil.ItemCallback<SR2TOCEntry> =

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
@@ -3,8 +3,10 @@ package org.librarysimplified.r2.views.internal
 import android.content.res.Resources
 import android.view.View
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import org.joda.time.format.DateTimeFormatterBuilder
 import org.librarysimplified.r2.api.SR2Bookmark
@@ -23,6 +25,8 @@ internal class SR2TOCBookmarkViewHolder(
     this.rootView.findViewById(R.id.bookmarkDelete)
   private val bookmarkDate: TextView =
     this.rootView.findViewById(R.id.bookmarkDate)
+  private val bookmarkDeleteLoading: ProgressBar =
+    this.rootView.findViewById(R.id.bookmarkDeleteLoading)
   private val bookmarkProgressText: TextView =
     this.rootView.findViewById(R.id.bookmarkProgressText)
   private val bookmarkTitleText: TextView =
@@ -64,6 +68,9 @@ internal class SR2TOCBookmarkViewHolder(
         this.bookmarkDelete.visibility = View.INVISIBLE
       }
     }
+
+    bookmarkDelete.isVisible = !bookmark.isBeingDeleted
+    bookmarkDeleteLoading.isVisible = bookmark.isBeingDeleted
 
     this.rootView.setOnClickListener {
       this.rootView.setOnClickListener(null)

--- a/org.librarysimplified.r2.views/src/main/res/layout/sr2_toc_bookmark_item.xml
+++ b/org.librarysimplified.r2.views/src/main/res/layout/sr2_toc_bookmark_item.xml
@@ -2,9 +2,9 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
   android:layout_width="match_parent"
   android:layout_height="112dp"
-  xmlns:tools="http://schemas.android.com/tools"
   android:background="?android:attr/selectableItemBackground"
   android:clickable="true"
   android:focusable="true">
@@ -29,10 +29,10 @@
     android:ellipsize="end"
     android:gravity="start|center_vertical"
     android:maxLines="1"
-    tools:text="@string/placeholder"
     app:layout_constraintEnd_toStartOf="@id/bookmarkDelete"
     app:layout_constraintStart_toEndOf="@id/bookmarkIcon"
-    app:layout_constraintTop_toTopOf="parent" />
+    app:layout_constraintTop_toTopOf="parent"
+    tools:text="@string/placeholder" />
 
   <TextView
     android:id="@+id/bookmarkTitle"
@@ -44,10 +44,10 @@
     android:ellipsize="end"
     android:gravity="start|center_vertical"
     android:maxLines="1"
-    tools:text="@string/placeholder"
     app:layout_constraintEnd_toStartOf="@id/bookmarkDelete"
     app:layout_constraintStart_toEndOf="@id/bookmarkIcon"
-    app:layout_constraintTop_toBottomOf="@id/bookmarkDate" />
+    app:layout_constraintTop_toBottomOf="@id/bookmarkDate"
+    tools:text="@string/placeholder" />
 
   <TextView
     android:id="@+id/bookmarkProgressText"
@@ -60,11 +60,11 @@
     android:ellipsize="end"
     android:gravity="start|top"
     android:maxLines="1"
-    tools:text="@string/placeholder"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toStartOf="@id/bookmarkDelete"
     app:layout_constraintStart_toEndOf="@id/bookmarkIcon"
-    app:layout_constraintTop_toBottomOf="@id/bookmarkTitle" />
+    app:layout_constraintTop_toBottomOf="@id/bookmarkTitle"
+    tools:text="@string/placeholder" />
 
   <ImageView
     android:id="@+id/bookmarkDelete"
@@ -76,5 +76,16 @@
     android:src="@drawable/sr2_bookmark_delete"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintTop_toTopOf="parent" />
+
+  <ProgressBar
+    android:id="@+id/bookmarkDeleteLoading"
+    android:layout_width="48dp"
+    android:layout_height="48dp"
+    android:layout_marginTop="16dp"
+    android:layout_marginEnd="16dp"
+    android:visibility="gone"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintTop_toTopOf="parent"
+    tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
+++ b/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
@@ -24,7 +24,7 @@
   <string name="tocAccessBookmarkDelete">Delete A Bookmark</string>
   <string name="tocBookmarkDelete">Delete</string>
   <string name="tocBookmarkDeleteMessage">Are you sure you want to delete this bookmark?</string>
-  <string name="tocBookmarkDeleteErrorMessage">There was an error while deleting the bookmark</string>
+  <string name="tocBookmarkDeleteErrorMessage">There was an error deleting the bookmark</string>
   <string name="tocBookmarks">Bookmarks</string>
   <string name="tocTitle">Table Of Contents</string>
   <string name="tocError">No entries available.</string>

--- a/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
+++ b/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
@@ -24,6 +24,7 @@
   <string name="tocAccessBookmarkDelete">Delete A Bookmark</string>
   <string name="tocBookmarkDelete">Delete</string>
   <string name="tocBookmarkDeleteMessage">Are you sure you want to delete this bookmark?</string>
+  <string name="tocBookmarkDeleteErrorMessage">There was an error while deleting the bookmark</string>
   <string name="tocBookmarks">Bookmarks</string>
   <string name="tocTitle">Table Of Contents</string>
   <string name="tocError">No entries available.</string>


### PR DESCRIPTION
**What's this do?**
This PR updates the UI when creating and deleting a bookmark so the user has some feedback about what's happening. This PR also updates both "create" and "delete" operations so the bookmarks list can be updated when a bookmark is successfully/unsuccessfully created or deleted.

**Why are we doing this? (w/ JIRA link if applicable)**
As explained in this PR, the bookmarks sometimes failed to be deleted so now we're updating this in order to keep the bookmark as it was in the list if it failed to be deleted, otherwise the user might get a bit confused

**How should this be tested? / Do these changes have associated tests?**
Follow [this PR](https://github.com/ThePalaceProject/android-core/pull/191) steps

**Dependencies for merging? Releasing to production?**
[This PR](https://github.com/ThePalaceProject/android-core/pull/191) needs to be updated so these changes can be visible

**Have you updated the changelog?**
Yes

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 