### PR TITLE
Publish the correct events on page turns

### DIFF
--- a/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Event.kt
+++ b/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Event.kt
@@ -90,6 +90,7 @@ sealed class SR2Event {
      * A bookmark was created.
      */
 
+    @Deprecated("This event will stop being published soon.")
     data class SR2BookmarkCreated(
       val bookmark: SR2Bookmark
     ) : SR2BookmarkEvent()
@@ -98,6 +99,7 @@ sealed class SR2Event {
      * A bookmark was deleted.
      */
 
+    @Deprecated("This event will stop being published soon.")
     data class SR2BookmarkDeleted(
       val bookmark: SR2Bookmark
     ) : SR2BookmarkEvent()

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
@@ -306,11 +306,21 @@ internal class SR2Controller private constructor(
           bookProgress = this.currentBookProgress,
           uri = null
         )
-        val newBookmarks = this.bookmarks.toMutableList()
-        newBookmarks.removeAll { bookmark -> bookmark.type == LAST_READ }
-        newBookmarks.add(newBookmark)
-        this.bookmarks = newBookmarks.toList()
-        this.eventSubject.onNext(SR2BookmarkCreated(newBookmark))
+
+        this.eventSubject.onNext(
+          SR2BookmarkCreate(
+            newBookmark,
+            onBookmarkCreationCompleted = { createdBookmark ->
+              if (createdBookmark != null) {
+                val newBookmarks = this.bookmarks.toMutableList()
+                newBookmarks.removeAll { bookmark -> bookmark.type == LAST_READ }
+                newBookmarks.add(createdBookmark)
+                this.bookmarks = newBookmarks.toList()
+                this.eventSubject.onNext(SR2BookmarkCreated(createdBookmark))
+              }
+            }
+          )
+        )
       }
     }
   }


### PR DESCRIPTION
**What's this do?**
This adjusts the code so that the new "BookmarkCreate" event is published when the page is turned. This also deprecates the old "BookmarkCreated" and "BookmarkDeleted" events.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-185

**How should this be tested? / Do these changes have associated tests?**
This is tested in the main app.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
Yes.

**Did someone actually run this code to verify it works?**
@io7m Ran it using the main app locally.