### PR TITLE
Automatically open keyboard when entering searching screen

### DIFF
--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/search/SR2SearchFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/search/SR2SearchFragment.kt
@@ -1,10 +1,13 @@
 package org.librarysimplified.r2.views.search
 
+import android.content.Context
 import android.os.Bundle
 import android.text.InputType
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -44,6 +47,7 @@ class SR2SearchFragment private constructor(
   private lateinit var readerModel: SR2ReaderViewModel
   private lateinit var searchAdapter: SR2SearchResultAdapter
   private lateinit var searchResultsList: RecyclerView
+  private lateinit var searchView: SearchView
   private lateinit var toolbar: Toolbar
 
   private var controllerEvents: Disposable? = null
@@ -135,6 +139,13 @@ class SR2SearchFragment private constructor(
     super.onStop()
   }
 
+  override fun onHiddenChanged(hidden: Boolean) {
+    super.onHiddenChanged(hidden)
+    if (!hidden) {
+      showKeyboard()
+    }
+  }
+
   private fun close() {
     SR2UIThread.checkIsUIThread()
 
@@ -143,7 +154,7 @@ class SR2SearchFragment private constructor(
 
   private fun configureSearch() {
     val search = toolbar.menu.findItem(R.id.readerMenuSearch)
-    val searchView = search.actionView as SearchView
+    searchView = search.actionView as SearchView
 
     searchView.inputType = InputType.TYPE_CLASS_TEXT
     searchView.isIconified = false
@@ -169,7 +180,7 @@ class SR2SearchFragment private constructor(
       }
     })
 
-    searchView.requestFocus()
+    showKeyboard()
 
     this.controllerEvents =
       this.readerModel.controllerEvents.subscribe(this::onControllerEvent)
@@ -210,6 +221,14 @@ class SR2SearchFragment private constructor(
       is SR2Event.SR2CommandEvent.SR2CommandSearchResults -> {
         this.readerModel.extractResults(event)
       }
+    }
+  }
+
+  private fun showKeyboard() {
+    searchView.post {
+      searchView.requestFocus()
+      (requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)
+        ?.showSoftInput(requireView().findFocus(), 0)
     }
   }
 }


### PR DESCRIPTION
**What's this do?**
This PR adds logic to automatically open the keyboard when entering the searching screen

**Why are we doing this? (w/ JIRA link if applicable)**
There's a suggestion on [this card](https://ebce-lyrasis.atlassian.net/browse/PP-426?focusedCommentId=11623) comments to include this feature so the app can behave [like this](https://github.com/ThePalaceProject/android-r2/assets/79104027/8c2f8ea3-c00b-484c-96ac-83707b14a0a4)



**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Open any Epub
Click on the "Search" icon
Confirm the keyboard is automatically opened
Return to the previous screen
Reopen the searching screen
Confirm the keyboard is automatically opened

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 