### PR TITLE
Added highlighting feature to searching terms on EPUB pages

### DIFF
--- a/README-CHANGES.xml
+++ b/README-CHANGES.xml
@@ -29,9 +29,10 @@
         <c:change date="2023-07-03T00:00:00+00:00" summary="Fixed bug of bookmark not being deleted right after being added."/>
       </c:changes>
     </c:release>
-    <c:release date="2023-09-21T11:53:22+00:00" is-open="true" ticket-system="org.nypl.jira" version="2.0.1">
+    <c:release date="2023-10-06T09:12:42+00:00" is-open="true" ticket-system="org.nypl.jira" version="2.0.1">
       <c:changes>
-        <c:change date="2023-09-21T11:53:22+00:00" summary="Implemented searching feature on EPUBs."/>
+        <c:change date="2023-09-21T00:00:00+00:00" summary="Implemented searching feature on EPUBs."/>
+        <c:change date="2023-10-06T09:12:42+00:00" summary="Added highlighting feature to searching terms on EPUB pages."/>
       </c:changes>
     </c:release>
   </c:releases>

--- a/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Command.kt
+++ b/org.librarysimplified.r2.api/src/main/java/org/librarysimplified/r2/api/SR2Command.kt
@@ -133,4 +133,20 @@ sealed class SR2Command {
   data class ThemeSet(
     val theme: SR2Theme,
   ) : SR2Command()
+
+  /**
+   * Highlight or clear the highlight for the given terms.
+   */
+
+  data class HighlightTerms(
+    val searchingTerms: String,
+    val clearHighlight: Boolean,
+  ) : SR2Command()
+
+  /**
+   * Highlight the current searching terms if a new chapter is loaded and a search has already been
+   * done.
+   */
+
+  object HighlightCurrentTerms : SR2Command()
 }

--- a/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoActivity.kt
+++ b/org.librarysimplified.r2.demo/src/main/java/org/librarysimplified/r2/demo/DemoActivity.kt
@@ -125,6 +125,34 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
     this.viewSubscription?.dispose()
   }
 
+  override fun onBackPressed() {
+    if (this.tocFragment.isVisible) {
+      this.tocClose()
+    } else if (this.searchFragment.isVisible) {
+      this.searchClose()
+    } else {
+      super.onBackPressed()
+    }
+  }
+
+  private fun tocClose() {
+    SR2UIThread.checkIsUIThread()
+
+    this.supportFragmentManager.beginTransaction()
+      .hide(this.tocFragment)
+      .show(this.readerFragment)
+      .commit()
+  }
+
+  private fun searchClose() {
+    SR2UIThread.checkIsUIThread()
+
+    this.supportFragmentManager.beginTransaction()
+      .hide(this.searchFragment)
+      .show(this.readerFragment)
+      .commit()
+  }
+
   private fun onControllerBecameAvailable(reference: SR2ControllerReference) {
     this.controller = reference.controller
 
@@ -215,7 +243,7 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
 
     return when (event) {
       SR2ReaderViewNavigationClose ->
-        this.supportFragmentManager.popBackStack()
+        this.onBackPressed()
       SR2ReaderViewNavigationOpenTOC ->
         this.openTOC()
       is SR2ControllerBecameAvailable ->
@@ -246,8 +274,7 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
       transaction.add(R.id.demoFragmentArea, searchFragment)
     }
 
-    transaction.addToBackStack(null)
-      .commit()
+    transaction.commit()
   }
 
   private fun openTOC() {
@@ -260,8 +287,7 @@ class DemoActivity : AppCompatActivity(R.layout.demo_activity_host) {
       transaction.add(R.id.demoFragmentArea, tocFragment)
     }
 
-    transaction.addToBackStack(null)
-      .commit()
+    transaction.commit()
   }
 
   /**

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
@@ -215,6 +215,8 @@ internal class SR2Controller private constructor(
 
   private var searchIterator: SearchIterator? = null
 
+  private var searchingTerms = ""
+
   @Volatile
   private var themeMostRecent: SR2Theme =
     this.configuration.theme
@@ -346,6 +348,7 @@ internal class SR2Controller private constructor(
     return this.executeCommandSubmission(command)
   }
 
+  private var clear = false
   private fun executeCommandSubmission(
     command: SR2CommandSubmission,
   ): ListenableFuture<*> {
@@ -388,6 +391,12 @@ internal class SR2Controller private constructor(
 
       is SR2Command.CancelSearch ->
         this.executeCommandCancelSearch()
+
+      is SR2Command.HighlightTerms ->
+        this.executeCommandHighlightTerms(apiCommand)
+
+      SR2Command.HighlightCurrentTerms ->
+        this.executeCommandHighlightCurrentTerms()
     }
   }
 
@@ -585,6 +594,51 @@ internal class SR2Controller private constructor(
 
   private fun executeCommandOpenPagePrevious(): ListenableFuture<*> {
     return this.waitForWebViewAvailability().executeJS(SR2JavascriptAPIType::openPagePrevious)
+  }
+
+  /**
+   * Execute the [SR2Command.HighlightTerms] command.
+   */
+
+  private fun executeCommandHighlightTerms(
+    apiCommand: SR2Command.HighlightTerms,
+  ): ListenableFuture<*> {
+    if (searchingTerms.isBlank() && apiCommand.searchingTerms.isBlank()) {
+      return Futures.immediateFuture(Unit)
+    }
+
+    val clearHighlight = apiCommand.clearHighlight
+
+    // if the searching terms are blank, it means the user wants to clear the current highlighted
+    // terms, so we need to pass those same highlighted terms
+    val future = if (apiCommand.searchingTerms.isBlank()) {
+      val currentTerms = searchingTerms
+      this.waitForWebViewAvailability()
+        .executeJS { js -> js.highlightSearchingTerms(currentTerms, clearHighlight) }
+    } else {
+      this.waitForWebViewAvailability()
+        .executeJS { js -> js.highlightSearchingTerms(apiCommand.searchingTerms, clearHighlight) }
+    }
+    searchingTerms = apiCommand.searchingTerms
+
+    return future
+  }
+
+  /**
+   * Execute the [SR2Command.HighlightCurrentTerms] command.
+   */
+
+  private fun executeCommandHighlightCurrentTerms(): ListenableFuture<*> {
+    if (searchingTerms.isBlank()) {
+      return Futures.immediateFuture(Unit)
+    }
+    return this.waitForWebViewAvailability()
+      .executeJS { js ->
+        js.highlightSearchingTerms(
+          searchingTerms = searchingTerms,
+          clearHighlight = false,
+        )
+      }
   }
 
   /**

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2Controller.kt
@@ -215,6 +215,7 @@ internal class SR2Controller private constructor(
 
   private var searchIterator: SearchIterator? = null
 
+  @Volatile
   private var searchingTerms = ""
 
   @Volatile
@@ -348,7 +349,6 @@ internal class SR2Controller private constructor(
     return this.executeCommandSubmission(command)
   }
 
-  private var clear = false
   private fun executeCommandSubmission(
     command: SR2CommandSubmission,
   ): ListenableFuture<*> {

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2JavascriptAPI.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2JavascriptAPI.kt
@@ -53,6 +53,14 @@ internal class SR2JavascriptAPI(
   }
 
   @UiThread
+  override fun highlightSearchingTerms(
+    searchingTerms: String,
+    clearHighlight: Boolean,
+  ): ListenableFuture<String> {
+    return this.executeJavascript("readium.highlightSearchingTerms(\"$searchingTerms\", $clearHighlight);")
+  }
+
+  @UiThread
   override fun openPageNext(): ListenableFuture<String> {
     val future = this.executeJavascript("readium.scrollRight();")
     future.addListener(
@@ -61,6 +69,7 @@ internal class SR2JavascriptAPI(
           "false" -> {
             this.commandQueue.submitCommand(SR2Command.OpenChapterNext)
           }
+
           else -> {
           }
         }
@@ -79,6 +88,7 @@ internal class SR2JavascriptAPI(
           "false" -> {
             this.commandQueue.submitCommand(SR2Command.OpenChapterPrevious(atEnd = true))
           }
+
           else -> {
           }
         }
@@ -111,8 +121,10 @@ internal class SR2JavascriptAPI(
     when (value) {
       LIGHT, DAY ->
         this.setUserProperty("appearance", "readium-default-on")
+
       DARK, NIGHT ->
         this.setUserProperty("appearance", "readium-night-on")
+
       SEPIA ->
         this.setUserProperty("appearance", "readium-sepia-on")
     }
@@ -153,6 +165,7 @@ internal class SR2JavascriptAPI(
           this.setUserProperty("advancedSettings", ""),
           this.setUserProperty("fontOverride", ""),
         )
+
       SR2_PUBLISHER_DEFAULT_CSS_DISABLED ->
         Futures.allAsList(
           this.setUserProperty("advancedSettings", "readium-advanced-on"),

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2JavascriptAPIType.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2JavascriptAPIType.kt
@@ -12,6 +12,15 @@ import org.librarysimplified.r2.api.SR2ScrollingMode
 internal interface SR2JavascriptAPIType {
 
   /**
+   * Highlight or clear the highlight for the given searching terms.
+   */
+  @UiThread
+  fun highlightSearchingTerms(
+    searchingTerms: String,
+    clearHighlight: Boolean,
+  ): ListenableFuture<String>
+
+  /**
    * Open the next page in the current chapter.
    */
 

--- a/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2WebViewClient.kt
+++ b/org.librarysimplified.r2.vanilla/src/main/java/org/librarysimplified/r2/vanilla/internal/SR2WebViewClient.kt
@@ -94,6 +94,7 @@ internal class SR2WebViewClient(
       try {
         if (this.errors.isEmpty()) {
           this.logger.debug("onPageFinished: {} succeeded", url)
+          this.commandQueue.submitCommand(SR2Command.HighlightCurrentTerms)
           this.future.set(Unit)
           return
         } else {

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/SR2ReaderFragment.kt
@@ -7,8 +7,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.View.GONE
-import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.ProgressBar
@@ -158,7 +156,8 @@ class SR2ReaderFragment private constructor(
     }
 
     this.configureForTheme(this.controller?.themeNow() ?: this.parameters.theme)
-    this.viewsShowLoading()
+    this.viewsHandleLoadingState(showLoading = true)
+
     return view
   }
 
@@ -279,31 +278,31 @@ class SR2ReaderFragment private constructor(
     val context = this.context ?: return
     this.logger.debug("chapterTitle=${event.chapterTitle}")
     if (event.chapterTitle == null) {
-      this.positionTitleView.visibility = GONE
+      this.positionTitleView.visibility = View.GONE
     } else {
       this.positionTitleView.text = event.chapterTitle
-      this.positionTitleView.visibility = VISIBLE
+      this.positionTitleView.visibility = View.VISIBLE
     }
 
     if (event.currentPage == null || event.pageCount == null) {
-      this.positionPageView.visibility = GONE
+      this.positionPageView.visibility = View.GONE
     } else {
       this.positionPageView.text = context.getString(R.string.progress_page, event.currentPage, event.pageCount)
-      this.positionPageView.visibility = VISIBLE
+      this.positionPageView.visibility = View.VISIBLE
     }
 
     val bookProgressPercent = event.bookProgressPercent
     if (bookProgressPercent == null) {
-      this.positionPercentView.visibility = GONE
-      this.progressView.visibility = GONE
+      this.positionPercentView.visibility = View.GONE
+      this.progressView.visibility = View.GONE
     } else {
       this.positionPercentView.text = this.getString(R.string.progress_percent, bookProgressPercent)
       this.progressView.apply {
         this.max = 100
         this.progress = bookProgressPercent
       }
-      this.positionPercentView.visibility = VISIBLE
-      this.progressView.visibility = VISIBLE
+      this.positionPercentView.visibility = View.VISIBLE
+      this.progressView.visibility = View.VISIBLE
     }
     this.reconfigureBookmarkMenuItem(event.locator)
   }
@@ -422,13 +421,13 @@ class SR2ReaderFragment private constructor(
       }
 
       is SR2CommandExecutionRunningLong -> {
-        this.viewsShowLoading()
+        this.viewsHandleLoadingState(showLoading = true)
       }
 
       is SR2CommandExecutionSucceeded,
       is SR2CommandExecutionFailed,
       -> {
-        this.viewsHideLoading()
+        this.viewsHandleLoadingState(showLoading = false)
       }
 
       is SR2Event.SR2ExternalLinkSelected -> {
@@ -444,25 +443,20 @@ class SR2ReaderFragment private constructor(
     this.toolbar.isVisible = uiVisible
   }
 
-  private fun viewsHideLoading() {
+  private fun viewsHandleLoadingState(showLoading: Boolean) {
     SR2UIThread.checkIsUIThread()
 
-    if (this.webView.visibility != View.VISIBLE) {
-      this.webView.visibility = View.VISIBLE
+    val (webViewVisibility, loadingVisibility) = if (showLoading) {
+      View.INVISIBLE to View.VISIBLE
+    } else {
+      View.VISIBLE to View.INVISIBLE
     }
-    if (this.loadingView.visibility != View.INVISIBLE) {
-      this.loadingView.visibility = View.INVISIBLE
-    }
-  }
 
-  private fun viewsShowLoading() {
-    SR2UIThread.checkIsUIThread()
-
-    if (this.webView.visibility != View.INVISIBLE) {
-      this.webView.visibility = View.INVISIBLE
+    if (this.webView.visibility != webViewVisibility) {
+      this.webView.visibility = webViewVisibility
     }
-    if (this.loadingView.visibility != View.VISIBLE) {
-      this.loadingView.visibility = View.VISIBLE
+    if (this.loadingView.visibility != loadingVisibility) {
+      this.loadingView.visibility = loadingVisibility
     }
   }
 

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/search/SR2SearchFragment.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/search/SR2SearchFragment.kt
@@ -3,7 +3,6 @@ package org.librarysimplified.r2.views.search
 import android.content.Context
 import android.os.Bundle
 import android.text.InputType
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -51,6 +50,7 @@ class SR2SearchFragment private constructor(
   private lateinit var toolbar: Toolbar
 
   private var controllerEvents: Disposable? = null
+  private var searchingTerms = ""
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -81,6 +81,12 @@ class SR2SearchFragment private constructor(
 
     this.searchAdapter = SR2SearchResultAdapter(
       onItemClicked = { locator ->
+        this.controller.submitCommand(
+          SR2Command.HighlightTerms(
+            searchingTerms = searchView.query.toString(),
+            clearHighlight = false,
+          ),
+        )
         this.controller.submitCommand(
           SR2Command.OpenChapter(
             SR2Locator.SR2LocatorPercent(
@@ -164,6 +170,15 @@ class SR2SearchFragment private constructor(
       if (searchView.query.isNotBlank()) {
         searchView.setQuery("", false)
       } else {
+        controller.submitCommand(
+          SR2Command.HighlightTerms(
+            searchingTerms = searchingTerms,
+            clearHighlight = true,
+          ),
+        )
+
+        searchingTerms = ""
+
         close()
       }
       true


### PR DESCRIPTION
**What's this do?**
This PR adds searching terms highlighting on the EPUB pages by adding logic to handle a command to highlight some searching terms and to clear the highlighting of those terms.

**Why are we doing this? (w/ JIRA link if applicable)**~
There's a [ticket](https://ebce-lyrasis.atlassian.net/browse/PP-479) to add this feature to the Palace app

**How should this be tested? / Do these changes have associated tests?**
Open the Palace app
Select LYRASIS Reads
Open any EPUB
Click on the Search icon
Type any query
Select any of the searching results
Confirm you're redirected to the clicked result's location and that the terms you searched for are highlighted
Scroll some pages to find more occurrences of your search and confirm they're all highlighted
Go back to the searching results screen and clear your query and press the "clear button" again
Confirm you're redirected to the EPUB and your searching terms are no longer highlighted

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
Tested by @nunommts 