### PR TITLE
PP-651, PP-650: Stop using the legacy alert dialog

### DIFF
--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2SettingsDialog.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2SettingsDialog.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.SeekBar
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.res.ResourcesCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.tabs.TabLayout
 import io.reactivex.disposables.CompositeDisposable
 import org.librarysimplified.r2.api.SR2ColorScheme
@@ -72,7 +72,7 @@ internal class SR2SettingsDialog private constructor() {
       val eventSubscriptions = CompositeDisposable()
 
       val dialog =
-        AlertDialog.Builder(context)
+        MaterialAlertDialogBuilder(context)
           .setView(R.layout.sr2_settings)
           .setOnDismissListener {
             eventSubscriptions.dispose()

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
@@ -5,9 +5,9 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import org.joda.time.format.DateTimeFormatterBuilder
 import org.librarysimplified.r2.api.SR2Bookmark
 import org.librarysimplified.r2.api.SR2Bookmark.Type.EXPLICIT
@@ -93,7 +93,7 @@ internal class SR2TOCBookmarkViewHolder(
     bookmark: SR2Bookmark,
     onBookmarkDeleteRequested: (SR2Bookmark) -> Unit,
   ) {
-    AlertDialog.Builder(this.rootView.context)
+    MaterialAlertDialogBuilder(this.rootView.context)
       .setMessage(R.string.tocBookmarkDeleteMessage)
       .setPositiveButton(R.string.tocBookmarkDelete) { dialog, which ->
         onBookmarkDeleteRequested.invoke(bookmark)

--- a/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
+++ b/org.librarysimplified.r2.views/src/main/java/org/librarysimplified/r2/views/internal/SR2TOCBookmarkViewHolder.kt
@@ -95,6 +95,10 @@ internal class SR2TOCBookmarkViewHolder(
   ) {
     MaterialAlertDialogBuilder(this.rootView.context)
       .setMessage(R.string.tocBookmarkDeleteMessage)
+      .setCancelable(true)
+      .setNegativeButton(R.string.tocBookmarkCancel) { dialog, which ->
+        dialog.dismiss()
+      }
       .setPositiveButton(R.string.tocBookmarkDelete) { dialog, which ->
         onBookmarkDeleteRequested.invoke(bookmark)
         dialog.dismiss()

--- a/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
+++ b/org.librarysimplified.r2.views/src/main/res/values/sr2_strings.xml
@@ -26,6 +26,7 @@
   <string name="settingsAa">A a</string>
   <string name="tocAccessBookmarkDelete">Delete A Bookmark</string>
   <string name="tocBookmarkDelete">Delete</string>
+  <string name="tocBookmarkCancel">Cancel</string>
   <string name="tocBookmarkDeleteMessage">Are you sure you want to delete this bookmark?</string>
   <string name="tocBookmarkDeleteErrorMessage">There was an error deleting the bookmark</string>
   <string name="tocBookmarks">Bookmarks</string>


### PR DESCRIPTION
**What's this do?**
This stops using the legacy AlertDialog, because it behaves poorly with the Material 3 theme.

**Why are we doing this? (w/ JIRA link if applicable)**
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-651
Affects: https://ebce-lyrasis.atlassian.net/browse/PP-650

**How should this be tested? / Do these changes have associated tests?**
Check that the buttons look sane when confirming bookmark deletion.

**Dependencies for merging? Releasing to production?**
None.

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@io7m Tried it.